### PR TITLE
[Fix] Jacoco config

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,8 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <JetCodeStyleSettings>
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </JetCodeStyleSettings>
     <codeStyleSettings language="XML">
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
@@ -111,6 +114,9 @@
           </section>
         </rules>
       </arrangement>
+    </codeStyleSettings>
+    <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </codeStyleSettings>
   </code_scheme>
 </component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/app/src/main/java/com/github/nisrulz/example/androidautomations/MyJavaExample.java
+++ b/app/src/main/java/com/github/nisrulz/example/androidautomations/MyJavaExample.java
@@ -1,0 +1,7 @@
+package com.github.nisrulz.example.androidautomations;
+
+public class MyJavaExample {
+    String getClassNameAsString() {
+        return this.getClass().getSimpleName();
+    }
+}

--- a/app/src/test/java/com/github/nisrulz/example/androidautomations/MyJavaExampleTest.java
+++ b/app/src/test/java/com/github/nisrulz/example/androidautomations/MyJavaExampleTest.java
@@ -1,0 +1,15 @@
+package com.github.nisrulz.example.androidautomations;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MyJavaExampleTest {
+
+    private MyJavaExample myJavaExample = new MyJavaExample();
+
+    @Test
+    public void testGetClassName() {
+        assertEquals("MyJavaExample", myJavaExample.getClassNameAsString());
+    }
+}

--- a/configs/jacoco.gradle
+++ b/configs/jacoco.gradle
@@ -52,23 +52,27 @@ configure(subprojects) { subproject ->
         // Define what to exclude from coverage report
         // UI, "noise", generated classes, platform classes, etc.
         final fileFilter = [
-                '**/R.*',
-                '**/R$*.*',
-                '**/BuildConfig.*',
-                '**/Manifest*.*',
-                'android/**/*.*'
+            '**/R.class',
+            '**/R$*.class',
+            '**/*$ViewInjector*.*',
+            '**/BuildConfig.*',
+            '**/Manifest*.*',
+            '**/*Test*.*',
+            '**/*Fragment*.*',
+            '**/*Activity*.*',
+            'android/**/*.*',
         ]
 
         // Collect class files
         final kotlinClassTree = "/tmp/kotlin-classes/$buildTypeName/**"
-        final javaClassTree = "/intermediates/javac/$buildTypeName/**"
+        final javaClassTree = "/intermediates/javac/$buildTypeName/classes/**"
         final combinedClassTree = fileTree(dir: "${subproject.buildDir}", excludes: fileFilter, includes: [javaClassTree, kotlinClassTree])
         classDirectories.setFrom files(combinedClassTree)
 
         // Collect source files
         final kotlinSrc = "/src/main/kotlin/**"
         final javaSrc = "/src/main/java/**"
-        final combinedSrc = fileTree(dir: "${subproject.buildDir}", excludes: fileFilter, includes: [javaSrc, kotlinSrc])
+        final combinedSrc = fileTree(dir: "${subproject.projectDir}", excludes: fileFilter, includes: [javaSrc, kotlinSrc])
         sourceDirectories.setFrom files(combinedSrc)
 
         // Collect all *.exec files


### PR DESCRIPTION
- fix paths
- add java code and make sure it is covered in coverage

After running
```bash
./gradlew jacocoFullReport
```
Resulting generated html report
<img width="1005" alt="Screen Shot 2020-05-23 at 4 57 50 PM" src="https://user-images.githubusercontent.com/2096087/82733783-a9183a00-9d16-11ea-9350-0e6c53c35533.png">
